### PR TITLE
Update Contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@
 
 # Contributors
 
+Thanks goes to these wonderful people
+([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!


### PR DESCRIPTION
Adds the missing placeholder and content for All Contributors.

This is normally _not necessary_ (manually speaking) but it should help in troubleshooting https://github.com/all-contributors/all-contributors-bot/issues/199.